### PR TITLE
Update deprecation section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Important**: PayPal Mobile SDKs are Deprecated. The APIs powering them will remain operational long enough for merchants to migrate, but the SDKs themselves will no longer be updated. Please use [Braintree Direct](https://www.braintreepayments.com/products/braintree-direct) in [supported countries](https://www.braintreepayments.com/country-selection). In other countries, use [Express Checkout](https://developer.paypal.com/docs/accept-payments/express-checkout/ec-braintree-sdk/get-started/) and choose the Braintree SDK integration option.
+**Important**: This PayPal Android SDK is Deprecated. The APIs powering them will remain operational long enough for merchants to migrate, but the SDKs themselves will no longer be updated. Please use the [PayPal Android Checkout SDK](https://github.com/paypal/android-checkout-sdk). Reference the [Developer Documentation](https://developer.paypal.com/docs/business/native-checkout/android/) for getting started.
 
 PayPal Android SDK
 ==================


### PR DESCRIPTION
Add links to the Android Checkout SDK and its documentation in the README deprecation section.